### PR TITLE
Use stpsf as webbpsf

### DIFF
--- a/notebooks/test_distortions.ipynb
+++ b/notebooks/test_distortions.ipynb
@@ -27,7 +27,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import webbpsf_ext, webbpsf\n",
+    "import webbpsf_ext\n",
+    "import stpsf as webbpsf\n",
     "webbpsf_ext.setup_logging('WARN', verbose=False)"
    ]
   },

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ scipy>=1.11.4
 tqdm
 pysiaf
 poppy
-webbpsf>=1.2.2
+stpsf>=2.0.0

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ install_requires = [
     'tqdm>4',
     'synphot>=1.2.1',
     'poppy>=1.1.0',
-    'webbpsf>=1.3.0',
+    'stpsf>=2.0.0',
     'pysiaf>=0.22.0',
 ]
 

--- a/webbpsf_ext/__init__.py
+++ b/webbpsf_ext/__init__.py
@@ -55,7 +55,7 @@ class Conf(_config.ConfigNamespace):
         if (data_path is None) or (data_path == ''):
             print("WARNING: Environment variable $WEBBPSF_EXT_PATH is not set!")
             import stpsf as webbpsf
-            data_path = webbpsf.utils.get_webbpsf_data_path()
+            data_path = webbpsf.utils.get_stpsf_data_path()
             print("  Setting WEBBPSF_EXT_PATH to WEBBPSF_PATH directory:")
             print(f"  {data_path}")
 

--- a/webbpsf_ext/__init__.py
+++ b/webbpsf_ext/__init__.py
@@ -54,7 +54,7 @@ class Conf(_config.ConfigNamespace):
         data_path = os.getenv('WEBBPSF_EXT_PATH')
         if (data_path is None) or (data_path == ''):
             print("WARNING: Environment variable $WEBBPSF_EXT_PATH is not set!")
-            import webbpsf
+            import stpsf as webbpsf
             data_path = webbpsf.utils.get_webbpsf_data_path()
             print("  Setting WEBBPSF_EXT_PATH to WEBBPSF_PATH directory:")
             print(f"  {data_path}")

--- a/webbpsf_ext/bandpasses.py
+++ b/webbpsf_ext/bandpasses.py
@@ -56,7 +56,7 @@ def miri_filter(filter, **kwargs):
     transmission throughput as indicated on JDOCS.
     """
 
-    import webbpsf
+    import stpsf as webbpsf
     
     filter = filter.upper()
     filt_dir = Path(webbpsf.utils.get_webbpsf_data_path()) / 'MIRI/filters/'

--- a/webbpsf_ext/bandpasses.py
+++ b/webbpsf_ext/bandpasses.py
@@ -59,7 +59,7 @@ def miri_filter(filter, **kwargs):
     import stpsf as webbpsf
     
     filter = filter.upper()
-    filt_dir = Path(webbpsf.utils.get_webbpsf_data_path()) / 'MIRI/filters/'
+    filt_dir = Path(webbpsf.utils.get_stpsf_data_path()) / 'MIRI/filters/'
     fname = f'{filter}_throughput.fits'
 
     bp_name = filter

--- a/webbpsf_ext/conftest.py
+++ b/webbpsf_ext/conftest.py
@@ -11,7 +11,8 @@ except ImportError:
 
 import os
 import pytest
-import webbpsf, webbpsf_ext
+import stpsf as webbpsf
+import webbpsf_ext
 
 from webbpsf_ext.logging_utils import setup_logging
 setup_logging(level='ERROR', verbose=False)

--- a/webbpsf_ext/logging_utils.py
+++ b/webbpsf_ext/logging_utils.py
@@ -1,6 +1,7 @@
 import sys
 
-import webbpsf, poppy
+import stpsf as webbpsf
+import poppy
 from . import conf
 
 import logging

--- a/webbpsf_ext/opds.py
+++ b/webbpsf_ext/opds.py
@@ -15,7 +15,7 @@ from astropy.io import fits
 import astropy.units as u
 
 # WebbPSF
-import webbpsf
+import stpsf as webbpsf
 from webbpsf.opds import OTE_Linear_Model_WSS
 from webbpsf.utils import get_webbpsf_data_path
 

--- a/webbpsf_ext/opds.py
+++ b/webbpsf_ext/opds.py
@@ -17,7 +17,7 @@ import astropy.units as u
 # WebbPSF
 import stpsf as webbpsf
 from webbpsf.opds import OTE_Linear_Model_WSS
-from webbpsf.utils import get_webbpsf_data_path
+from webbpsf.utils import get_stpsf_data_path
 
 # Logging
 from . import conf
@@ -53,9 +53,9 @@ def OPDFile_to_HDUList(file, slice=0):
 
         if 'JWST_OTE_OPD' in file:
             # Location of JWST_OTE_OPD*.fits.gz
-            opd_dir = get_webbpsf_data_path()
+            opd_dir = get_stpsf_data_path()
         else:
-            opd_dir = os.path.join(get_webbpsf_data_path(),inst,'OPD')
+            opd_dir = os.path.join(get_stpsf_data_path(),inst,'OPD')
         hdul = fits.open(os.path.join(opd_dir, file))
     ndim = len(hdul[0].data.shape)
 
@@ -117,7 +117,7 @@ class OTE_WFE_Drift_Model(OTE_Linear_Model_WSS):
         transmission = kwargs.pop('transmission', None)
         import six
         if isinstance(transmission, six.string_types) and (not os.path.exists(transmission)):
-            wdir = webbpsf.utils.get_webbpsf_data_path()
+            wdir = webbpsf.utils.get_stpsf_data_path()
             transmission = os.path.join(wdir, transmission)
             kwargs['transmission'] = transmission
         

--- a/webbpsf_ext/utils.py
+++ b/webbpsf_ext/utils.py
@@ -7,7 +7,8 @@ import matplotlib.pyplot as plt
 import os, sys
 import six
 
-import webbpsf, poppy, pysiaf
+import stpsf as webbpsf
+import poppy, pysiaf
 
 try:
     from webbpsf.webbpsf_core import get_siaf_with_caching

--- a/webbpsf_ext/utils.py
+++ b/webbpsf_ext/utils.py
@@ -61,7 +61,7 @@ def check_fitsgz(opd_file, inst_str=None):
         string to determine if to look in instrument OPD directory,
         otherwise assume file name is in webbpsf data base directory.
     """
-    from webbpsf.utils import get_webbpsf_data_path
+    from webbpsf.utils import get_stpsf_data_path
 
     # Check if instrument name is in OPD file name
     # If so, then this is in instrument OPD directory
@@ -76,9 +76,9 @@ def check_fitsgz(opd_file, inst_str=None):
     # Get file directory
     if inst_str is None:
         # Location of JWST_OTE_OPD_*.fits.gz
-        opd_dir = get_webbpsf_data_path()
+        opd_dir = get_stpsf_data_path()
     else:
-        opd_dir = os.path.join(get_webbpsf_data_path(),inst_str,'OPD')
+        opd_dir = os.path.join(get_stpsf_data_path(),inst_str,'OPD')
     opd_fullpath = os.path.join(opd_dir, opd_file)
 
     # Check if file exists 

--- a/webbpsf_ext/webbpsf_ext_core.py
+++ b/webbpsf_ext/webbpsf_ext_core.py
@@ -2254,7 +2254,7 @@ def _get_opd_info(self, opd=None, pupil=None, HDUL_to_OTELM=True):
         #header['WFEDRIFT'] = (self.wfe_drift, "WFE drift amount [nm]")
 
         if isinstance(pupil, six.string_types) and (not os.path.exists(pupil)):
-            wdir = webbpsf.utils.get_webbpsf_data_path()
+            wdir = webbpsf.utils.get_stpsf_data_path()
             pupil = os.path.join(wdir, pupil)
 
         if isinstance(pupil, six.string_types):


### PR DESCRIPTION
The package formerly known as "webbpsf" is now being called "stpsf". 

This PR updates webbpsf_ext's package requirements to depend on `stpsf` (>2.0) instead of `webbpsf`, and implements `import stpsf as webbpsf` throughout the code.  


(Incidentally I think it's totally fine to keep this package as `webbpsf_ext` long-term, instead of e.g. renaming the whole thing to `stpsf_ext`. The intent is for both names to be supported for a long while. We're going to be releasing soon also a version of "webbpsf" which transparently imports `stpsf` and renames it to `webbpsf`, so in some sense this PR is not necessary -- but I think it makes the code more transparent and clear to use the new name to be more explicit about where the code will be coming from.)